### PR TITLE
emitter is always defined and it should stop script execution after e…

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -134,14 +134,13 @@ class Api
                     );
             }
 
-            if ($this->emitter) {
-                // cannot do anything about it
-                $this->emitter->emit($this->response);
-            }
-
-            // no emitter (is that possible at all ?)
-            return $ret;
+            // emit response and exit
+            $this->emitter->emit($this->response);
+            exit;
         }
+
+        // @todo Should we also stop script execution if no response is received or just ignore that?
+        //exit;
     }
 
     /**


### PR DESCRIPTION
emitter is always defined and it should stop script execution after emitting otherwise it tries to match more services.

For example:
```
$restapi->get('/ping', function() {
   return 'Pong';
});

// here we authorize - check for token
$restapi->authorize();
```

if I request service /ping, then it also tries to authorize, but it should stop script execution as soon as /ping service is matched and response is emitted.