### PR TITLE
Add ability to set only few REST methods.

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -199,6 +199,7 @@ class Api
         // value is not ID
         if (is_array($value)) {
             $field = empty($value[0]) ? $m->title_field : $value[0];
+
             return $m->loadBy($field, $value[1]);
         }
 
@@ -406,7 +407,7 @@ class Api
                 // limit fields
                 $model->onlyFields($this->getAllowedFields($model, 'read'));
 
-//var_dump($id);
+                //var_dump($id);
 
                 // load model and get field values
                 return $this->loadModelByValue($model, $id)->get();

--- a/src/Api.php
+++ b/src/Api.php
@@ -407,8 +407,6 @@ class Api
                 // limit fields
                 $model->onlyFields($this->getAllowedFields($model, 'read'));
 
-                //var_dump($id);
-
                 // load model and get field values
                 return $this->loadModelByValue($model, $id)->get();
             };


### PR DESCRIPTION
for example:
`$restapi->rest('/country', new Model_Country($smbo->db), ['read']);`
only will set GET methods.


Also now it supports loadBy() like this:
```
api/country/2 = load(2)
api/country/code:GB = loadBy('code', 'GB')
api/country/name:United%20Kingdom = loadBy('name', 'United Kingdom')
api/country/:United+Kingdom = loadBy($model->title_field, 'United Kingdom')
```
