### PR TITLE
GET by id now also goes through exportModel()

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -408,8 +408,9 @@ class Api
                 // limit fields
                 $model->onlyFields($this->getAllowedFields($model, 'read'));
 
-                // load model and get field values
-                return $this->loadModelByValue($model, $id)->get();
+                // single record should also go through exportModel for API-specific changes
+                $model->addCondition($model->id_field, $id);
+                return $model;
             };
             $this->get($pattern.'/:id', $f);
         }


### PR DESCRIPTION
API has its own function to export a model when using get: exportModel(); I find this function very sensible, e.g. to alter time fields (currently exported as Datetime object).
However, the current rest implementation bypassed this function when only a single record identified by ID was requested. This PR unifies GET handling in API: they all run through exportModel().