### PR TITLE
Do not rely on Exception having getParams() method in caughtException

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -484,8 +484,10 @@ class Api
     public function caughtException(\Exception $e)
     {
         $params = [];
-        foreach ($e->getParams() as $key => $val) {
-            $params[$key] = $e->toString($val);
+        if($e instanceOf \atk4\core\Exception) {
+            foreach ($e->getParams() as $key => $val) {
+                $params[$key] = $e->toString($val);
+            }
         }
 
         $this->response =


### PR DESCRIPTION
We cannot rely on that the Exception processed in caughtException() is a descendant of \atk4\core\Exception. Its possible that its another Exception which does not have this method. trying to call it will make the function fail.